### PR TITLE
feat: Create chat display skeleton

### DIFF
--- a/src/components/ChatDisplay.tsx
+++ b/src/components/ChatDisplay.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Message } from "~/interfaces/Message";
+import { ChatMessage } from "./ChatMessage";
+
+type ChatDisplayProps = {
+  messages: (Message & { id: number })[];
+};
+
+export const ChatDisplay = (props: ChatDisplayProps): JSX.Element => {
+  return (
+    <div className="chat-display">
+      {props.messages.map((message) => {
+        return (
+          <ChatMessage
+            key={message.id}
+            id={message.id}
+            sender={message.sender}
+            message={message.message}
+            timestamp={message.timestamp}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Message } from "~/interfaces/Message";
+
+export const ChatMessage = (props: Message): JSX.Element => {
+  return (
+    <div className="chat-message">
+      <div className="sender">{props.sender}</div>
+      <div className="message">{props.message}</div>
+      <div className="timestamp">{props.timestamp}</div>
+    </div>
+  );
+};

--- a/src/interfaces/Message.ts
+++ b/src/interfaces/Message.ts
@@ -1,0 +1,6 @@
+export interface Message {
+  id: number;
+  sender: string;
+  message: string;
+  timestamp: string;
+}

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -1,0 +1,46 @@
+import { NextPage } from "next";
+import { ChatDisplay } from "~/components/ChatDisplay";
+import { Message } from "~/interfaces/Message";
+
+interface Props {
+  messages: Message[];
+}
+
+const Chat: NextPage<Props> = ({ messages }) => {
+  return (
+    <div>
+      <ChatDisplay messages={messages} />
+    </div>
+  );
+};
+
+export async function getServerSideProps(context: any) {
+  const messages = [
+    {
+      id: 1,
+      sender: "Stranger",
+      message: "Hello World",
+      timestamp: "2023/1/24/23:52",
+    },
+    {
+      id: 2,
+      sender: "Stranger",
+      message: "This chat is awesome!",
+      timestamp: "2023/1/24/23:52",
+    },
+    {
+      id: 3,
+      sender: "Founder",
+      message: "This is the future",
+      timestamp: "2023/1/25/00:00",
+    },
+  ];
+
+  return {
+    props: {
+      messages,
+    },
+  };
+}
+
+export default Chat;


### PR DESCRIPTION
以下を実装
- チャット画面用のNext ページ
- メッセージの配列を扱うコンポーネント
- 単体のメッセージを扱うコンポーネント
- メッセージ用の型

それぞれスケルトンレベルなので今後細かい改良が必要

   
![image](https://user-images.githubusercontent.com/35527421/214339157-69bd3d3f-14d8-4591-ab68-62360a8f01e8.png)
