### PR TITLE
feat: Display sender name

### DIFF
--- a/src/components/ChatDisplay.tsx
+++ b/src/components/ChatDisplay.tsx
@@ -1,3 +1,4 @@
+import { useSession } from "next-auth/react";
 import React, { useState } from "react";
 import { Message } from "~/interfaces/Message";
 import { ChatForm } from "./ChatForm";
@@ -9,12 +10,15 @@ interface ChatDisplayProps {
 
 export const ChatDisplay = (props: ChatDisplayProps): JSX.Element => {
   const { messages: initialMessages } = props;
+  const { data: session } = useSession();
 
   const [chatMessages, setChatMessages] = useState(initialMessages);
 
   const onSendMessage = (message: string) => {
+    const sender = session?.user?.name || "Stranger";
+
     const newMessage = {
-      sender: "Stranger",
+      sender: sender,
       message: message,
       timestamp: new Date().toString(),
     };

--- a/src/components/ChatDisplay.tsx
+++ b/src/components/ChatDisplay.tsx
@@ -39,7 +39,7 @@ export const ChatDisplay = (props: ChatDisplayProps): JSX.Element => {
           );
         })}
       </ul>
-      <ChatForm onSendMessage={onSendMessage} />;
+      <ChatForm onSendMessage={onSendMessage} />
     </div>
   );
 };

--- a/src/pages/chat.tsx
+++ b/src/pages/chat.tsx
@@ -1,5 +1,6 @@
 import { NextPage } from "next";
 import { ChatDisplay } from "~/components/ChatDisplay";
+import { BasicLayout } from "~/components/Layout/BasicLayout";
 import { Message } from "~/interfaces/Message";
 
 interface Props {
@@ -8,9 +9,9 @@ interface Props {
 
 const Chat: NextPage<Props> = ({ messages }) => {
   return (
-    <div>
+    <BasicLayout>
       <ChatDisplay messages={messages} />
-    </div>
+    </BasicLayout>
   );
 };
 


### PR DESCRIPTION
以下を実装
- メッセージの上に送信したユーザー名を表示
  - <img width="428" alt="image" src="https://user-images.githubusercontent.com/35527421/214793294-4dc186a9-b97b-4b01-a96b-f8aea3dcb28f.png">
- ログインユーザーのみ /chat を利用できるように追加実装
